### PR TITLE
adds each as an ignored @ rule since it can be used

### DIFF
--- a/services/app/.stylelintrc.yml
+++ b/services/app/.stylelintrc.yml
@@ -15,6 +15,7 @@ rules:
         - 'else'
         - 'for'
         - 'mixin'
+        - 'each'
   block-no-empty: null
   color-named:
     - never


### PR DESCRIPTION
This prevents usage of @each (available via postcss-advanced-variables) from triggering an error in stylelint.