### PR TITLE
Fix spacing units in storybook

### DIFF
--- a/source/01-global/02-spacing/space.stories.tsx
+++ b/source/01-global/02-spacing/space.stories.tsx
@@ -40,11 +40,8 @@ const SpacingComponent = ({ spacing }: { spacing: SpacingOptions }) => {
           .map(([name, unit]) => (
             <tr key={`spacing-${name}`}>
               <td>{name}</td>
-              <td>
-                {parseInt(unit) / baseFontSize}
-                rem
-              </td>
               <td>{unit}</td>
+              <td>{parseFloat(unit) * baseFontSize}px</td>
               <td>
                 <div
                   style={{


### PR DESCRIPTION
Corrects the rem and px values displayed on the spacing example story.