### PR TITLE
Disable prettier-plugin-organize-imports for generated Icon files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -13,9 +13,9 @@
   "useTabs": false,
   "overrides": [
     {
-      "files": ["source/01-global/icon/**/*.tsx"],
+      "files": ["source/01-global/icon/**/*.tsx", "source/01-global/icon/**/*.svg"],
       "options": {
-        "organizeImportsSkipDestructiveCodeActions": true
+        "plugins": []
       }
     }
   ]

--- a/lib/icon-template.js
+++ b/lib/icon-template.js
@@ -53,9 +53,12 @@ const iconTemplate = (
   }
 
   return tpl`
+// organize-imports-ignore
+
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.
+
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
 ${imports};

--- a/source/01-global/icon/icons/AngleDoubleLeft.tsx
+++ b/source/01-global/icon/icons/AngleDoubleLeft.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/AngleDoubleRight.tsx
+++ b/source/01-global/icon/icons/AngleDoubleRight.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/AngleDown.tsx
+++ b/source/01-global/icon/icons/AngleDown.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/AngleLeft.tsx
+++ b/source/01-global/icon/icons/AngleLeft.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/AngleRight.tsx
+++ b/source/01-global/icon/icons/AngleRight.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/AngleUp.tsx
+++ b/source/01-global/icon/icons/AngleUp.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/Close.tsx
+++ b/source/01-global/icon/icons/Close.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/Facebook.tsx
+++ b/source/01-global/icon/icons/Facebook.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/Linkedin.tsx
+++ b/source/01-global/icon/icons/Linkedin.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/Rss.tsx
+++ b/source/01-global/icon/icons/Rss.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.

--- a/source/01-global/icon/icons/Twitter.tsx
+++ b/source/01-global/icon/icons/Twitter.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 // This component is automatically generated.
 // SVGs should be added to icon/svgs.
 // See the project documentation for more information.


### PR DESCRIPTION
Fixes issue reported at https://forumone.slack.com/archives/CN5MT8WJK/p1711114527376429?thread_ts=1711113349.756309&cid=CN5MT8WJK where `npm run build-icons` resulted in a SyntaxError.