### PR TITLE
Container query mixin

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -16,6 +16,7 @@ rules:
         - 'for'
         - 'mixin'
         - 'each'
+        - 'content'
   block-no-empty: null
   color-named:
     - never

--- a/package-lock.json
+++ b/package-lock.json
@@ -16331,7 +16331,7 @@
     },
     "node_modules/postcss-advanced-variables": {
       "version": "4.0.0",
-      "resolved": "git+ssh://git@github.com/kmonahan/postcss-advanced-variables.git#2884ed863358511a7f1255113a0220ef861d75c8",
+      "resolved": "git+ssh://git@github.com/kmonahan/postcss-advanced-variables.git#ab7526096eed46d47c2e6eabcd3fcfc20ea90b80",
       "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
@@ -16341,7 +16341,7 @@
         "node": "^10 || ^12 || >=14"
       },
       "peerDependencies": {
-        "postcss": "^8.2.4"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {

--- a/source/00-config/mixins.css
+++ b/source/00-config/mixins.css
@@ -1,6 +1,7 @@
 @import 'mixins/accessibility';
 @import 'mixins/button';
 @import 'mixins/clearfix';
+@import 'mixins/container-query';
 @import 'mixins/display-text';
 @import 'mixins/focus';
 @import 'mixins/grids';

--- a/source/00-config/mixins/container-query.css
+++ b/source/00-config/mixins/container-query.css
@@ -1,0 +1,86 @@
+/**
+ * Create a min-width container query.
+ * @param {Number} $breakpoint - width value.
+ * @param {String} $container_name - name of container.
+ */
+@mixin container-query-min($breakpoint, $container_name: '') {
+  @if $container_name != '' {
+    @container $container_name (inline-size >= $breakpoint) {
+      @content;
+    }
+  } @else  {
+    @container (inline-size >= $breakpoint) {
+      @content;
+    }
+  }
+}
+
+/**
+  * Create a max-width container query.
+  * @param {Number} $breakpoint - width value.
+  * @param {String} $container_name - name of container.
+  * @param {Boolean} $subtract_1_from_max - whether to subtract 1px from $breakpoint value.
+ */
+@mixin container-query-max(
+  $breakpoint,
+  $container_name: '',
+  $subtract_1_from_max: false
+) {
+  @if $container_name != '' {
+    @if $subtract_1_from_max == true {
+      @container $container_name (inline-size < $breakpoint) {
+        @content;
+      }
+    } @else  {
+      @container $container_name (inline-size <= $breakpoint) {
+        @content;
+      }
+    }
+  } @else  {
+    @if $subtract_1_from_max == true {
+      @container (inline-size < $breakpoint) {
+        @content;
+      }
+    } @else  {
+      @container (inline-size <= $breakpoint) {
+        @content;
+      }
+    }
+  }
+}
+
+/**
+  * Create a container query with both min-width and max-width.
+  * @param {Number} $breakpoint-min - width value.
+  * @param {Number} $breakpoint-max - width value.
+  * @param {String} $container_name - name of container.
+  * @param {Boolean} $subtract_1_from_max - whether to subtract 1px from $breakpoint-max value.
+ */
+@mixin container-query-min-max(
+  $breakpoint-min,
+  $breakpoint-max,
+  $container_name: '',
+  $subtract_1_from_max: false
+) {
+  @if $container_name != '' {
+    @if $subtract_1_from_max == true {
+      @container $container_name ($breakpoint-min <= inline-size < $breakpoint-max) {
+        @content;
+      }
+    } @else  {
+      @container $container_name ($breakpoint-min <= inline-size <= $breakpoint-max) {
+        @content;
+      }
+    }
+  } @else  {
+    @if $subtract_1_from_max == true {
+      @container ($breakpoint-min <= inline-size < $breakpoint-max) {
+        @content;
+      }
+    } @else  {
+      @container ($breakpoint-min <= inline-size <= $breakpoint-max) {
+        @content;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ports https://github.com/forumone/gesso/pull/773 from Gesso Drupal and adjusts syntax to work with postcss-advanced-variables, which doesn't support conditional variables like Sass does, but instead handles scope similar to JavaScript. Also uses the range syntax for container queries and removes the default container-query() mixin, since that proved to be one nested level too far for postcss.