### PR TITLE
Use type predicate function.

### DIFF
--- a/source/06-utility/storybook/getCssVariables.ts
+++ b/source/06-utility/storybook/getCssVariables.ts
@@ -2,6 +2,9 @@
 // CSSGroupingRule, so we fake it.
 type CSSRulesWithLayers = CSSRule | CSSGroupingRule;
 
+const isCSSStyleRule = (val: CSSRule): val is CSSStyleRule =>
+  val instanceof CSSStyleRule;
+
 function getCssVariables(): string[][] {
   return Array.from(document.styleSheets)
     .map(sheet => {
@@ -17,12 +20,12 @@ function getCssVariables(): string[][] {
       return allStyles.concat(
         sheet
           .flat()
-          .filter(r => r instanceof CSSStyleRule)
+          .filter(isCSSStyleRule)
           .reduce((cssVars, rule) => {
-            const props = Array.from((rule as CSSStyleRule).style)
+            const props = Array.from(rule.style)
               .map(propName => [
                 propName.trim(),
-                (rule as CSSStyleRule).style.getPropertyValue(propName).trim(),
+                rule.style.getPropertyValue(propName).trim(),
               ])
               .filter(([propName]) => propName.indexOf('--') === 0);
             return [...cssVars, ...props];


### PR DESCRIPTION
I was getting TS/lint errors from time to time on this file. This fixes that by using a type predicate function in the filter.

Error this fixed:
```bash
$ npm test

> nextjs-project@1.1.4 test
> npm run lint && npm run tsc


> nextjs-project@1.1.4 lint
> next lint && stylelint "source/**/*.css"


./source/06-utility/storybook/getCssVariables.ts
22:39  Error: This assertion is unnecessary since it does not change the type of the expression.  @typescript-eslint/no-unnecessary-type-assertion
25:18  Error: This assertion is unnecessary since it does not change the type of the expression.  @typescript-eslint/no-unnecessary-type-assertion

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
```