### PR TITLE
Update query for slug

### DIFF
--- a/starterkits/drupal/app/api/preview/route.ts
+++ b/starterkits/drupal/app/api/preview/route.ts
@@ -9,7 +9,7 @@ async function GET(request: NextRequest) {
   }
 
   const query = request.nextUrl.searchParams;
-  let slug = query.get('slug');
+  let slug = query.get('path');
   if (!slug) {
     return;
   }


### PR DESCRIPTION
From https://github.com/forumone/nextjs-project/issues/182
Unintentionally we have run into some issues with getting the preview working using drupal project because we were using Next 2.0 module for drupal.

According to the [upgrade guide](https://next-drupal.org/docs/upgrade-guide) there was an update to the query parameter used in the URL. Also see code change [here](https://git.drupalcode.org/project/next/-/commit/379f88bfe306610051d77c6ca16a1a0cfaa9c8a1#bd79002d085a04c259272d59a3916bce4ac688ca_276_276).

This change to my eye seems to be the only issue of consequence from the Drupal side. Otherwise, NextJS seems to be working fine. Well this and the changes for OAuth.