### PR TITLE
[210] Update to Next.js 16

### DIFF
--- a/.svgrrc.js
+++ b/.svgrrc.js
@@ -50,6 +50,7 @@ module.exports = {
       ],
     },
   },
+  jsxRuntime: 'automatic',
   template: iconTemplate,
   indexTemplate,
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,22 +1,19 @@
-import { FlatCompat } from '@eslint/eslintrc';
 import f1BaseConfig from '@forumone/eslint-config-es5';
 import f1ReactConfig from '@forumone/eslint-config-react';
+import nextPlugin from '@next/eslint-plugin-next';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
-const compat = new FlatCompat({
-  // import.meta.dirname is available after Node.js v20.11.0
-  baseDirectory: import.meta.dirname,
-});
-
 const config = defineConfig([
-  globalIgnores(['**/Icon/icons/*.tsx']),
-  compat.config({
-    extends: ['plugin:@next/next/recommended'],
-  }),
   f1BaseConfig,
   {
     files: ['*.tsx', '*.jsx'],
     extends: [f1ReactConfig],
+    plugins: {
+      '@next/next': nextPlugin,
+    },
+    rules: {
+      ...nextPlugin.configs.recommended.rules,
+    },
   },
   {
     files: ['**/*.stories.tsx', '**/*Args.tsx'],
@@ -43,6 +40,15 @@ const config = defineConfig([
       '@typescript-eslint/ban-ts-comment': 'off',
     },
   },
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+    // Ignore generated Icons
+    '**/icon/icons/*.tsx',
+  ]),
 ]);
 
 export default config;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -5,9 +5,6 @@ const StylelintWebpackPlugin = require('stylelint-webpack-plugin');
 module.exports = {
   reactStrictMode: true,
   basePath,
-  eslint: {
-    dirs: ['source', 'app'],
-  },
   /**
    * Custom Webpack Config
    * https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "nextjs-project",
       "version": "2.2.2",
       "dependencies": {
-        "next": "16.0.3",
-        "react": "19.2.0",
-        "react-dom": "19.2.0",
+        "next": "~16.0.3",
+        "react": "~19.2.0",
+        "react-dom": "~19.2.0",
         "react-select": "^5.10.2"
       },
       "devDependencies": {
@@ -20,7 +20,7 @@
         "@forumone/eslint-config-react": "^3.0.5",
         "@forumone/tiny-mustache": "^3.0.5",
         "@inquirer/prompts": "^8.0.1",
-        "@next/eslint-plugin-next": "16.0.3",
+        "@next/eslint-plugin-next": "~16.0.3",
         "@storybook/addon-a11y": "^10.1.2",
         "@storybook/addon-docs": "^10.1.2",
         "@storybook/addon-links": "^10.1.2",
@@ -29,8 +29,8 @@
         "@svgr/babel-plugin-remove-jsx-attribute": "^8.0.0",
         "@svgr/cli": "^8.1.0",
         "@types/node": "^22.19.1",
-        "@types/react": "19.2.7",
-        "@types/react-dom": "19.2.3",
+        "@types/react": "~19.2.7",
+        "@types/react-dom": "~19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "change-case": "^5.4.4",
@@ -4921,9 +4921,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.3.tgz",
-      "integrity": "sha512-IqgtY5Vwsm14mm/nmQaRMmywCU+yyMIYfk3/MHZ2ZTJvwVbBn3usZnjMi1GacrMVzVcAxJShTCpZlPs26EdEjQ==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.10.tgz",
+      "integrity": "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -4937,9 +4937,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.3.tgz",
-      "integrity": "sha512-MOnbd92+OByu0p6QBAzq1ahVWzF6nyfiH07dQDez4/Nku7G249NjxDVyEfVhz8WkLiOEU+KFVnqtgcsfP2nLXg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.10.tgz",
+      "integrity": "sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==",
       "cpu": [
         "arm64"
       ],
@@ -4953,9 +4953,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.3.tgz",
-      "integrity": "sha512-i70C4O1VmbTivYdRlk+5lj9xRc2BlK3oUikt3yJeHT1unL4LsNtN7UiOhVanFdc7vDAgZn1tV/9mQwMkWOJvHg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.10.tgz",
+      "integrity": "sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==",
       "cpu": [
         "x64"
       ],
@@ -4969,9 +4969,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.3.tgz",
-      "integrity": "sha512-O88gCZ95sScwD00mn/AtalyCoykhhlokxH/wi1huFK+rmiP5LAYVs/i2ruk7xST6SuXN4NI5y4Xf5vepb2jf6A==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.10.tgz",
+      "integrity": "sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==",
       "cpu": [
         "arm64"
       ],
@@ -4985,9 +4985,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.3.tgz",
-      "integrity": "sha512-CEErFt78S/zYXzFIiv18iQCbRbLgBluS8z1TNDQoyPi8/Jr5qhR3e8XHAIxVxPBjDbEMITprqELVc5KTfFj0gg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.10.tgz",
+      "integrity": "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==",
       "cpu": [
         "arm64"
       ],
@@ -5001,9 +5001,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.3.tgz",
-      "integrity": "sha512-Tc3i+nwt6mQ+Dwzcri/WNDj56iWdycGVh5YwwklleClzPzz7UpfaMw1ci7bLl6GRYMXhWDBfe707EXNjKtiswQ==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.10.tgz",
+      "integrity": "sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==",
       "cpu": [
         "x64"
       ],
@@ -5017,9 +5017,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.3.tgz",
-      "integrity": "sha512-zTh03Z/5PBBPdTurgEtr6nY0vI9KR9Ifp/jZCcHlODzwVOEKcKRBtQIGrkc7izFgOMuXDEJBmirwpGqdM/ZixA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.10.tgz",
+      "integrity": "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==",
       "cpu": [
         "x64"
       ],
@@ -5033,9 +5033,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.3.tgz",
-      "integrity": "sha512-Jc1EHxtZovcJcg5zU43X3tuqzl/sS+CmLgjRP28ZT4vk869Ncm2NoF8qSTaL99gh6uOzgM99Shct06pSO6kA6g==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.10.tgz",
+      "integrity": "sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==",
       "cpu": [
         "arm64"
       ],
@@ -5049,9 +5049,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.3.tgz",
-      "integrity": "sha512-N7EJ6zbxgIYpI/sWNzpVKRMbfEGgsWuOIvzkML7wxAAZhPk1Msxuo/JDu1PKjWGrAoOLaZcIX5s+/pF5LIbBBg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.10.tgz",
+      "integrity": "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==",
       "cpu": [
         "x64"
       ],
@@ -12072,12 +12072,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.3.tgz",
-      "integrity": "sha512-Ka0/iNBblPFcIubTA1Jjh6gvwqfjrGq1Y2MTI5lbjeLIAfmC+p5bQmojpRZqgHHVu5cG4+qdIiwXiBSm/8lZ3w==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
+      "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.3",
+        "@next/env": "16.0.10",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -12090,14 +12090,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.3",
-        "@next/swc-darwin-x64": "16.0.3",
-        "@next/swc-linux-arm64-gnu": "16.0.3",
-        "@next/swc-linux-arm64-musl": "16.0.3",
-        "@next/swc-linux-x64-gnu": "16.0.3",
-        "@next/swc-linux-x64-musl": "16.0.3",
-        "@next/swc-win32-arm64-msvc": "16.0.3",
-        "@next/swc-win32-x64-msvc": "16.0.3",
+        "@next/swc-darwin-arm64": "16.0.10",
+        "@next/swc-darwin-x64": "16.0.10",
+        "@next/swc-linux-arm64-gnu": "16.0.10",
+        "@next/swc-linux-arm64-musl": "16.0.10",
+        "@next/swc-linux-x64-gnu": "16.0.10",
+        "@next/swc-linux-x64-musl": "16.0.10",
+        "@next/swc-win32-arm64-msvc": "16.0.10",
+        "@next/swc-win32-x64-msvc": "16.0.10",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nextjs-project",
       "version": "2.2.2",
       "dependencies": {
-        "next": "15.5.6",
+        "next": "16.0.3",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-select": "^5.10.2"
@@ -20,7 +20,7 @@
         "@forumone/eslint-config-react": "^3.0.5",
         "@forumone/tiny-mustache": "^3.0.5",
         "@inquirer/prompts": "^8.0.1",
-        "@next/eslint-plugin-next": "15.5.4",
+        "@next/eslint-plugin-next": "16.0.3",
         "@storybook/addon-a11y": "^10.1.2",
         "@storybook/addon-docs": "^10.1.2",
         "@storybook/addon-links": "^10.1.2",
@@ -29,8 +29,8 @@
         "@svgr/babel-plugin-remove-jsx-attribute": "^8.0.0",
         "@svgr/cli": "^8.1.0",
         "@types/node": "^22.19.1",
-        "@types/react": "19.2.2",
-        "@types/react-dom": "19.2.2",
+        "@types/react": "19.2.7",
+        "@types/react-dom": "19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "change-case": "^5.4.4",
@@ -4921,15 +4921,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.6.tgz",
-      "integrity": "sha512-3qBGRW+sCGzgbpc5TS1a0p7eNxnOarGVQhZxfvTdnV0gFI61lX7QNtQ4V1TSREctXzYn5NetbUsLvyqwLFJM6Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.3.tgz",
+      "integrity": "sha512-IqgtY5Vwsm14mm/nmQaRMmywCU+yyMIYfk3/MHZ2ZTJvwVbBn3usZnjMi1GacrMVzVcAxJShTCpZlPs26EdEjQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.4.tgz",
-      "integrity": "sha512-SR1vhXNNg16T4zffhJ4TS7Xn7eq4NfKfcOsRwea7RIAHrjRpI9ALYbamqIJqkAhowLlERffiwk0FMvTLNdnVtw==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.3.tgz",
+      "integrity": "sha512-6sPWmZetzFWMsz7Dhuxsdmbu3fK+/AxKRtj7OB0/3OZAI2MHB/v2FeYh271LZ9abvnM1WIwWc/5umYjx0jo5sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4937,9 +4937,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.6.tgz",
-      "integrity": "sha512-ES3nRz7N+L5Umz4KoGfZ4XX6gwHplwPhioVRc25+QNsDa7RtUF/z8wJcbuQ2Tffm5RZwuN2A063eapoJ1u4nPg==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.3.tgz",
+      "integrity": "sha512-MOnbd92+OByu0p6QBAzq1ahVWzF6nyfiH07dQDez4/Nku7G249NjxDVyEfVhz8WkLiOEU+KFVnqtgcsfP2nLXg==",
       "cpu": [
         "arm64"
       ],
@@ -4953,9 +4953,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.6.tgz",
-      "integrity": "sha512-JIGcytAyk9LQp2/nuVZPAtj8uaJ/zZhsKOASTjxDug0SPU9LAM3wy6nPU735M1OqacR4U20LHVF5v5Wnl9ptTA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.3.tgz",
+      "integrity": "sha512-i70C4O1VmbTivYdRlk+5lj9xRc2BlK3oUikt3yJeHT1unL4LsNtN7UiOhVanFdc7vDAgZn1tV/9mQwMkWOJvHg==",
       "cpu": [
         "x64"
       ],
@@ -4969,9 +4969,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.6.tgz",
-      "integrity": "sha512-qvz4SVKQ0P3/Im9zcS2RmfFL/UCQnsJKJwQSkissbngnB/12c6bZTCB0gHTexz1s6d/mD0+egPKXAIRFVS7hQg==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.3.tgz",
+      "integrity": "sha512-O88gCZ95sScwD00mn/AtalyCoykhhlokxH/wi1huFK+rmiP5LAYVs/i2ruk7xST6SuXN4NI5y4Xf5vepb2jf6A==",
       "cpu": [
         "arm64"
       ],
@@ -4985,9 +4985,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.6.tgz",
-      "integrity": "sha512-FsbGVw3SJz1hZlvnWD+T6GFgV9/NYDeLTNQB2MXoPN5u9VA9OEDy6fJEfePfsUKAhJufFbZLgp0cPxMuV6SV0w==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.3.tgz",
+      "integrity": "sha512-CEErFt78S/zYXzFIiv18iQCbRbLgBluS8z1TNDQoyPi8/Jr5qhR3e8XHAIxVxPBjDbEMITprqELVc5KTfFj0gg==",
       "cpu": [
         "arm64"
       ],
@@ -5001,9 +5001,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.6.tgz",
-      "integrity": "sha512-3QnHGFWlnvAgyxFxt2Ny8PTpXtQD7kVEeaFat5oPAHHI192WKYB+VIKZijtHLGdBBvc16tiAkPTDmQNOQ0dyrA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.3.tgz",
+      "integrity": "sha512-Tc3i+nwt6mQ+Dwzcri/WNDj56iWdycGVh5YwwklleClzPzz7UpfaMw1ci7bLl6GRYMXhWDBfe707EXNjKtiswQ==",
       "cpu": [
         "x64"
       ],
@@ -5017,9 +5017,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.6.tgz",
-      "integrity": "sha512-OsGX148sL+TqMK9YFaPFPoIaJKbFJJxFzkXZljIgA9hjMjdruKht6xDCEv1HLtlLNfkx3c5w2GLKhj7veBQizQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.3.tgz",
+      "integrity": "sha512-zTh03Z/5PBBPdTurgEtr6nY0vI9KR9Ifp/jZCcHlODzwVOEKcKRBtQIGrkc7izFgOMuXDEJBmirwpGqdM/ZixA==",
       "cpu": [
         "x64"
       ],
@@ -5033,9 +5033,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.6.tgz",
-      "integrity": "sha512-ONOMrqWxdzXDJNh2n60H6gGyKed42Ieu6UTVPZteXpuKbLZTH4G4eBMsr5qWgOBA+s7F+uB4OJbZnrkEDnZ5Fg==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.3.tgz",
+      "integrity": "sha512-Jc1EHxtZovcJcg5zU43X3tuqzl/sS+CmLgjRP28ZT4vk869Ncm2NoF8qSTaL99gh6uOzgM99Shct06pSO6kA6g==",
       "cpu": [
         "arm64"
       ],
@@ -5049,9 +5049,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.6.tgz",
-      "integrity": "sha512-pxK4VIjFRx1MY92UycLOOw7dTdvccWsNETQ0kDHkBlcFH1GrTLUjSiHU1ohrznnux6TqRHgv5oflhfIWZwVROQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.3.tgz",
+      "integrity": "sha512-N7EJ6zbxgIYpI/sWNzpVKRMbfEGgsWuOIvzkML7wxAAZhPk1Msxuo/JDu1PKjWGrAoOLaZcIX5s+/pF5LIbBBg==",
       "cpu": [
         "x64"
       ],
@@ -6204,18 +6204,18 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
-      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
-      "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -12072,12 +12072,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.6.tgz",
-      "integrity": "sha512-zTxsnI3LQo3c9HSdSf91O1jMNsEzIXDShXd4wVdg9y5shwLqBXi4ZtUUJyB86KGVSJLZx0PFONvO54aheGX8QQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.3.tgz",
+      "integrity": "sha512-Ka0/iNBblPFcIubTA1Jjh6gvwqfjrGq1Y2MTI5lbjeLIAfmC+p5bQmojpRZqgHHVu5cG4+qdIiwXiBSm/8lZ3w==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.6",
+        "@next/env": "16.0.3",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -12087,18 +12087,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.6",
-        "@next/swc-darwin-x64": "15.5.6",
-        "@next/swc-linux-arm64-gnu": "15.5.6",
-        "@next/swc-linux-arm64-musl": "15.5.6",
-        "@next/swc-linux-x64-gnu": "15.5.6",
-        "@next/swc-linux-x64-musl": "15.5.6",
-        "@next/swc-win32-arm64-msvc": "15.5.6",
-        "@next/swc-win32-x64-msvc": "15.5.6",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.0.3",
+        "@next/swc-darwin-x64": "16.0.3",
+        "@next/swc-linux-arm64-gnu": "16.0.3",
+        "@next/swc-linux-arm64-musl": "16.0.3",
+        "@next/swc-linux-x64-gnu": "16.0.3",
+        "@next/swc-linux-x64-musl": "16.0.3",
+        "@next/swc-win32-arm64-msvc": "16.0.3",
+        "@next/swc-win32-x64-msvc": "16.0.3",
+        "sharp": "^0.34.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "2.2.2",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "export": "next build && next export",
-    "lint": "next lint && stylelint \"source/**/*.css\"",
+    "dev": "next dev --webpack",
+    "build": "next build --webpack",
+    "start": "next start --webpack",
+    "export": "npm run build && next export",
+    "lint": "eslint \"app/**\" \"source/**\" && stylelint \"source/**/*.css\"",
     "prepare": "husky install",
     "prettier": "prettier --check app source/",
     "prettier:write": "prettier --write app source/",
@@ -24,9 +24,9 @@
     ">= 1% in US"
   ],
   "dependencies": {
-    "next": "15.5.6",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "next": "~16.0.3",
+    "react": "~19.2.0",
+    "react-dom": "~19.2.0",
     "react-select": "^5.10.2"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "@forumone/eslint-config-react": "^3.0.5",
     "@forumone/tiny-mustache": "^3.0.5",
     "@inquirer/prompts": "^8.0.1",
-    "@next/eslint-plugin-next": "15.5.4",
+    "@next/eslint-plugin-next": "~16.0.3",
     "@storybook/addon-a11y": "^10.1.2",
     "@storybook/addon-docs": "^10.1.2",
     "@storybook/addon-links": "^10.1.2",
@@ -45,8 +45,8 @@
     "@svgr/babel-plugin-remove-jsx-attribute": "^8.0.0",
     "@svgr/cli": "^8.1.0",
     "@types/node": "^22.19.1",
-    "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.2",
+    "@types/react": "~19.2.7",
+    "@types/react-dom": "~19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
     "change-case": "^5.4.4",
@@ -77,8 +77,8 @@
   },
   "overrides": {
     "csstype": "3.1.3",
-    "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.2",
+    "@types/react": "~19.2.7",
+    "@types/react-dom": "~19.2.3",
     "storybook": "$storybook"
   },
   "engines": {

--- a/source/01-global/icon/icons/AngleDoubleLeft.tsx
+++ b/source/01-global/icon/icons/AngleDoubleLeft.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/AngleDoubleRight.tsx
+++ b/source/01-global/icon/icons/AngleDoubleRight.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/AngleDown.tsx
+++ b/source/01-global/icon/icons/AngleDown.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/AngleLeft.tsx
+++ b/source/01-global/icon/icons/AngleLeft.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/AngleRight.tsx
+++ b/source/01-global/icon/icons/AngleRight.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/AngleUp.tsx
+++ b/source/01-global/icon/icons/AngleUp.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/Close.tsx
+++ b/source/01-global/icon/icons/Close.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/Facebook.tsx
+++ b/source/01-global/icon/icons/Facebook.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/Linkedin.tsx
+++ b/source/01-global/icon/icons/Linkedin.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/Rss.tsx
+++ b/source/01-global/icon/icons/Rss.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/source/01-global/icon/icons/Twitter.tsx
+++ b/source/01-global/icon/icons/Twitter.tsx
@@ -4,7 +4,6 @@
 // See the project documentation for more information.
 // tslint:disable:ordered-imports
 import clsx from 'clsx';
-import * as React from 'react';
 import type { SVGProps } from 'react';
 interface SVGRProps {
   title?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "noImplicitAny": true,
     "incremental": true,
     "strictBindCallApply": true,
@@ -47,7 +47,8 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.module.css",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Closes #204 and #210 . Updates to Next.js 16 and moves to the ESLint CLI instead of `next lint`. Does not move to Turbopack yet; I opened #214 for that.