### PR TITLE
[Fixes #242] Allow starting one service at a time

### DIFF
--- a/.ddev/commands/host/up
+++ b/.ddev/commands/host/up
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+## Description: Start ddev and selectively start PM2 services
+## Usage: up [nextjs|storybook|all]
+
+SERVICE=${1:-all}
+
+START_UP_SERVICE=${SERVICE} ddev start
+
+echo "--- Selective PM2 Startup: $SERVICE ---"
+
+case $SERVICE in
+  nextjs)
+    ddev exec pm2 start --name next node_modules/.bin/next -- dev --webpack
+    ;;
+  storybook)
+    ddev exec pm2 start --name storybook node_modules/.bin/storybook -- dev --no-open -p 6006
+    ;;
+  all)
+    ddev exec pm2 start --name next node_modules/.bin/next -- dev --webpack
+    ddev exec pm2 start --name storybook node_modules/.bin/storybook -- dev --no-open -p 6006
+    ;;
+  *)
+    echo "Usage: ddev up [nextjs|storybook|all]"
+    exit 1
+    ;;
+esac
+
+ddev exec pm2 status

--- a/.ddev/config.hooks.yaml
+++ b/.ddev/config.hooks.yaml
@@ -1,11 +1,14 @@
 hooks:
   post-start:
     # Detects to see if the node_modules folder exists
-    - exec: 'sh -c "[ ! -d node_modules ] && npm ci || return"'
+    - exec: 'sh -c "[ ! -d node_modules ] && npm ci || true"'
       service: web
-      # pm2 does not live in the node path, so have to call binary directly
-    - exec: pm2 start --name next node_modules/.bin/next -- dev --webpack
-      service: web
-      # pm2 does not live in the node path, so have to call binary directly
-    - exec: pm2 start --name storybook node_modules/.bin/storybook -- dev --no-open -p 6006
-      service: web
+    - exec-host: |
+        if [ -z "$START_UP_SERVICE" ]; then
+          ddev exec pm2 start --name next node_modules/.bin/next -- dev --webpack
+          ddev exec pm2 start --name storybook node_modules/.bin/storybook -- dev --no-open -p 6006
+
+          echo "Next time use one of these for faster startup:"
+          echo "> ddev up nextjs"
+          echo "> ddev up storybook"
+        fi

--- a/README.project.md
+++ b/README.project.md
@@ -48,11 +48,21 @@ have more details about which to use when.
 
 ## Starting and stopping the project
 
-After following the "Initial Setup" instructions, you can start the local development server for the app by running:
+### Starting up Next.js
+
 ```bash
-ddev start
+ddev up nextjs
 ```
-Open [https://YOUR-PROJECT.ddev.site/](https://YOUR-PROJECT.ddev.site/) with your browser to see the app. If using storybook, use port `6006` by default to view it: [https://YOUR-PROJECT.ddev.site:6006](https://YOUR-PROJECT.ddev.site:6006).
+Open [https://YOUR-PROJECT.ddev.site/](https://YOUR-PROJECT.ddev.site/) to see the app.
+
+## Starting up Storybook
+
+```bash
+ddev up storybook
+```
+Open [https://YOUR-PROJECT.ddev.site:6006](https://YOUR-PROJECT.ddev.site:6006) (port 6006) to see Storybook.
+
+### Stopping
 
 To stop `ddev` for the project:
 ```bash


### PR DESCRIPTION
`ddev start` still works, but you can alternately use `ddev up nextjs` or `ddev up storybook` to start with a single service.